### PR TITLE
Turn on keeping the temporary dir for mftrace

### DIFF
--- a/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
@@ -15,7 +15,7 @@
     <key>italicAngle</key>
     <real>-14.0</real>
     <key>openTypeHeadCreated</key>
-    <string>2023/07/22 23:40:33</string>
+    <string>2023/12/24 21:46:49</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
@@ -15,7 +15,7 @@
     <key>italicAngle</key>
     <real>0.0</real>
     <key>openTypeHeadCreated</key>
-    <string>2023/07/22 23:40:31</string>
+    <string>2023/12/24 21:46:49</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Makefile
+++ b/sources/Makefile
@@ -2,16 +2,25 @@ PFA_FILES = \
 	cmr10.pfa cmti10.pfa \
 	cmmi10.pfa cmsy10.pfa \
 	ecrm10.pfa ecti10.pfa \
-	tcrm10.pfa tcti10.pfa
+	tcrm10.pfa tcti10.pfa \
+	eurorm.pfa euroit.pfa
 
 UFO_DIRS = \
 	ComputerModernClassic-Regular.ufo \
 	ComputerModernClassic-Italic.ufo
 
+MFTRACE = ./mftrace/mftrace.py --verbose --potrace
+
 all: $(PFA_FILES) $(UFO_DIRS)
 
+pfa: $(PFA_FILES)
+
+%.png: %.pbm
+	convert $< $@
+
 %.pfa: ./mftrace/mftrace.py
-	./mftrace/mftrace.py --potrace $(basename $@)
+	$(MFTRACE) --keep mftrace.$(basename $@) $(basename $@) \
+	  &> mftrace.$(basename $@).log
 
 cmmi10.pfa:
 cmr10.pfa:
@@ -19,21 +28,28 @@ cmsy10.pfa:
 cmti10.pfa:
 
 ecrm10.pfa:
-	./mftrace/mftrace.py --potrace \
+	$(MFTRACE) \
+	  --keep mftrace.$(basename $@) \
 	  -e /usr/share/texlive/texmf-dist/fonts/enc/dvips/base/ec.enc \
-	  $(basename $@)
+	  $(basename $@) &> mftrace.$(basename $@).log
+
 tcrm10.pfa:
-	./mftrace/mftrace.py --potrace \
+	$(MFTRACE) \
+	  --keep mftrace.$(basename $@) \
 	  -e /usr/share/texlive/texmf-dist/fonts/enc/dvips/cm-unicode/cmu-tc.enc \
-	  $(basename $@)
+	  $(basename $@) &> mftrace.$(basename $@).log
 
 ecti10.pfa:
-	./mftrace/mftrace.py --potrace \
-	  -e /usr/share/texlive/texmf-dist/fonts/enc/dvips/base/ec.enc $(basename $@)
+	$(MFTRACE) \
+	  --keep mftrace.$(basename $@) \
+	  -e /usr/share/texlive/texmf-dist/fonts/enc/dvips/base/ec.enc \
+	  $(basename $@) &> mftrace.$(basename $@).log
+
 tcti10.pfa:
-	./mftrace/mftrace.py --potrace \
+	$(MFTRACE) \
+	  --keep mftrace.$(basename $@) \
 	  -e /usr/share/texlive/texmf-dist/fonts/enc/dvips/cm-unicode/cmu-tc.enc \
-	  $(basename $@)
+	  $(basename $@) &> mftrace.$(basename $@).log
 
 eurorm.pfa:
 euroit.pfa:
@@ -47,3 +63,9 @@ ComputerModernClassic-Italic.ufo: $(PFA_FILES) fix.py fix_fontinfo.sh fix-fontin
 	fontforge -quiet -script fix.py cmti10.pfa ComputerModernClassic-Italic.ufo
 	./fix_fontinfo.sh ComputerModernClassic-Italic.ufo/fontinfo.plist
 	./fix-fontinfo.py ComputerModernClassic-Italic.ufo
+
+clean:
+	rm -rf $(PFA_FILES) $(addprefix mftrace.,$(basename $(PFA_FILES)))
+	rm mftrace.*.log
+
+.PHONY: clean


### PR DESCRIPTION
Keeping the temporary dir used by mftrace will help in comparing the bitmaps produced by METAFONT with the ones from the generated font.

This commit also adds the eurorm.pfa and euroit.pfa to the PFA_FILES in the sources/Makefile and also a clean target.