### PR TITLE
Add the testfont HTML output to the out/

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install sys tools/deps
       run: |
         sudo apt-get update
-        sudo apt-get install ttfautohint
+        sudo apt-get install ttfautohint texlive-base texlive-fonts-recommended potrace
         sudo snap install yq
     - uses: actions/cache@v3
       with:
@@ -46,6 +46,10 @@ jobs:
       continue-on-error: true
     - name: proof
       run: make proof
+    - name: proof-testfont
+      run: |
+        make -C sources/mftrace gf2pbm
+        make proof-testfont
     - name: setup site
       run: cp scripts/index.html out/index.html
     - name: Deploy

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ out/proof-bitmap/Italic: fonts/ttf/ComputerModernClassic-Italic.ttf sources/rend
 
 proof-bitmap: out/proof-bitmap/Regular out/proof-bitmap/Italic
 
+proof-testfont:
+	$(MAKE) -C sources/testfont
+	mkdir -p out/proof-testfont
+	cd sources/testfont && find . -name \*.html \-or -name \*.svg | cpio -pduv ../../out/proof-testfont
+
 images: venv build.stamp $(DRAWBOT_OUTPUT)
 	git add documentation/*.png && git commit -m "Rebuild images" documentation/*.png
 

--- a/sources/testfont/Makefile
+++ b/sources/testfont/Makefile
@@ -10,7 +10,7 @@ FONTS = \
 	eurorm \
 	euroit
 
-all: $(addsuffix .gf,$(FONTS))
+all: $(addsuffix .gf,$(FONTS)) index.html
 svg: $(addsuffix _svg,$(FONTS))
 html: index.html
 


### PR DESCRIPTION
To get this to work the following new packages were installed using `apt-get`:

  - texlive-base
  - texlive-fonts-recommended
  - potrace

This commit also adds index.html to the all target from sources/testfont/Makefile.