### PR TITLE
Properly mark the italic font as italic

### DIFF
--- a/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
@@ -13,11 +13,11 @@
     <key>guidelines</key>
     <array/>
     <key>italicAngle</key>
-    <real>0.0</real>
+    <real>-14.0</real>
     <key>note</key>
-    <string>2024-1-1: Created with FontForge (http://fontforge.org)</string>
+    <string>2024-1-2: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/01/02 05:42:53</string>
+    <string>2024/01/03 05:34:21</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>
@@ -47,7 +47,7 @@
     <key>openTypeOS2WinAscent</key>
     <integer>931</integer>
     <key>openTypeOS2WinDescent</key>
-    <integer>274</integer>
+    <integer>288</integer>
     <key>postscriptBlueValues</key>
     <array/>
     <key>postscriptFamilyBlues</key>
@@ -73,9 +73,9 @@
     <key>styleMapFamilyName</key>
     <string>Computer Modern Classic</string>
     <key>styleMapStyleName</key>
-    <string>regular</string>
+    <string>italic</string>
     <key>styleName</key>
-    <string>Regular</string>
+    <string>Italic</string>
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>

--- a/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
@@ -15,9 +15,9 @@
     <key>italicAngle</key>
     <real>0.0</real>
     <key>note</key>
-    <string>2024-1-1: Created with FontForge (http://fontforge.org)</string>
+    <string>2024-1-2: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/01/02 05:39:24</string>
+    <string>2024/01/03 05:34:13</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>
@@ -47,7 +47,7 @@
     <key>openTypeOS2WinAscent</key>
     <integer>931</integer>
     <key>openTypeOS2WinDescent</key>
-    <integer>274</integer>
+    <integer>288</integer>
     <key>postscriptBlueValues</key>
     <array/>
     <key>postscriptFamilyBlues</key>

--- a/sources/fix-fontinfo.py
+++ b/sources/fix-fontinfo.py
@@ -4,6 +4,10 @@ import defcon
 import sys
 
 f = defcon.Font(sys.argv[1])
+italic = 'Italic' in sys.argv[1]
+
+# For for FontBakery:com.google.fonts/check/italic_angle.
+f.info.italicAngle = -14.0 if italic else 0
 
 # Fix for FontBakery:com.google.fonts/check/font_copyright.
 f.info.copyright = 'Copyright 2023 The Computer Modern Classic Project Authors (https://github.com/razvanm/computer-modern-classic)'
@@ -15,7 +19,7 @@ f.info.openTypeOS2VendorID = 'GOOG'
 f.info.familyName = 'Computer Modern Classic'
 f.info.postscriptFullName = 'Computer Modern Classic'
 f.info.styleMapFamilyName = 'Computer Modern Classic'
-f.info.styleName = 'Regular' if f.info.italicAngle == 0 else 'Italic'
+f.info.styleName = 'Italic' if italic else 'Regular'
 # Stripping the ".ufo" ending gives us the font name.
 f.info.postscriptFontName = sys.argv[1].split('.')[0]
 
@@ -23,7 +27,7 @@ f.info.postscriptFontName = sys.argv[1].split('.')[0]
 f.info.openTypeOS2Type = []
 
 # Fix for FontBakery:com.google.fonts/check/fsselection.
-f.info.styleMapStyleName = 'regular' if f.info.italicAngle == 0 else 'italic'
+f.info.styleMapStyleName = 'italic' if italic else 'regular'
 
 # Fix for FontBakery:com.google.fonts/check/os2/use_typo_metrics.
 # Reference: https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fsselection
@@ -35,7 +39,7 @@ f.info.openTypeNameLicenseURL = 'https://scripts.sil.org/OFL'
 
 # Fix for FontBakery:com.google.fonts/check/family/win_ascent_and_descent.
 f.info.openTypeOS2WinAscent = 931
-f.info.openTypeOS2WinDescent = 274
+f.info.openTypeOS2WinDescent = 288
 
 # Fix for com.FontBakery:com.google.fonts/check/vertical_metrics.
 # Reference: https://googlefonts.github.io/gf-guide/metrics.html


### PR DESCRIPTION
This is another thing I missed to include in PR #9. After this the FAILs from FontBakery 0.10.8 goes from 13 down to 4.