### PR TITLE
Two small improvements to the Makefiles

### DIFF
--- a/sources/Makefile
+++ b/sources/Makefile
@@ -4,17 +4,24 @@ UFO_DIRS = \
 
 all: $(UFO_DIRS)
 
-ComputerModernClassic-Regular.ufo: ff-gen.py fix-fontinfo.py
-	fontforge -quiet -script $< $@ \
-	  testfont/ecrm10.gf testfont/ecrm10.tfm \
-	  testfont/tcrm10.gf testfont/tcrm10.tfm \
-	  testfont/eurorm.gf testfont/eurorm.tfm
+REGULAR_FILES = \
+	testfont/ecrm10.gf testfont/ecrm10.tfm \
+	testfont/tcrm10.gf testfont/tcrm10.tfm \
+	testfont/eurorm.gf testfont/eurorm.tfm
+
+ComputerModernClassic-Regular.ufo: ff-gen.py fix-fontinfo.py $(REGULAR_FILES)
+	fontforge -quiet -script $< $@ $(REGULAR_FILES)
 	./fix-fontinfo.py $@
 
-ComputerModernClassic-Italic.ufo: ff-gen.py fix-fontinfo.py
-	fontforge -quiet -script $< $@ \
+ITALIC_FILES = \
 	  testfont/ecti10.gf testfont/ecti10.tfm \
 	  testfont/tcti10.gf testfont/tcti10.tfm \
 	  testfont/euroit.gf testfont/euroit.tfm
+
+ComputerModernClassic-Italic.ufo: ff-gen.py fix-fontinfo.py $(ITALIC_FILES)
+	fontforge -quiet -script $< $@ $(ITALIC_FILES)
 	./fix-fontinfo.py $@
 
+.PHONY: clean
+clean:
+	rm -rf $(UFO_DIRS)

--- a/sources/testfont/Makefile
+++ b/sources/testfont/Makefile
@@ -17,9 +17,9 @@ gf: $(addsuffix .gf,$(FONTS))
 html: index.html
 
 # Reference for \smode: https://texfaq.org/FAQ-useMF
-%.gf:
+%.gf: custom.mf
 	mf-nowin -interaction=nonstopmode '\smode="custom"; input $(basename $@)'
-	ln -s $(basename $@).10000gf $(basename $@).gf
+	ln -f -s $(basename $@).10000gf $(basename $@).gf
 
 %.pl: %.tfm
 	tftopl -charcode-format=octal $< $@


### PR DESCRIPTION
The source/Makefile was improved by indicating the .gf and .tfm as dependencies while the rule for .gf files from sources/testfont/Makefile was improved by forcing the `ln -s` (necessary for a rebuild that is not clean).