### PR TITLE
Update GitPython to 3.1.41

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ fs==2.4.16
 gflanguages==0.8.9
 gftools==0.9.32
 gitdb==4.0.10
-GitPython==3.1.40
+GitPython==3.1.41
 glyphsets==0.6.11
 glyphsLib==6.2.2
 glyphtools==0.8.0


### PR DESCRIPTION
Dependabot reported that GitPython 3.1.40 is impacted by CVE-2024-22190.

The command I ran to do the update:
    
    pip install -U GitPython