### PR TITLE
Fix two FontBakery warnings relate to combining marks

### DIFF
--- a/sources/ComputerModernClassic-Italic.ufo/features.fea
+++ b/sources/ComputerModernClassic-Italic.ufo/features.fea
@@ -2606,7 +2606,7 @@ feature size {
 	\egrave \eacute \ecircumflex \edieresis \igrave \iacute \icircumflex \idieresis 
 	\eth \ntilde \ograve \oacute \ocircumflex \otilde \odieresis \oe \oslash \ugrave 
 	\uacute \ucircumflex \udieresis \yacute \thorn \germandbls \arrowleft 
-	\arrowright \uni0361.alt \uni0361 \uni2040.alt \uni2040 \uni2422 \quotesingle 
+	\arrowright \uni0361.alt \uni2040.alt \uni2040 \uni2422 \quotesingle 
 	\asteriskmath \uniFE66 \fraction \zerooldstyle \oneoldstyle \twooldstyle 
 	\threeoldstyle \fouroldstyle \fiveoldstyle \sixoldstyle \sevenoldstyle 
 	\eightoldstyle \nineoldstyle \angleleft \minus \angleright \uni2127 \circle 
@@ -2628,8 +2628,8 @@ feature size {
 @GDEF_Ligature = [\quotedblleft \quotedblright \quotedblbase \guillemotleft 
 	\guillemotright \endash \emdash \ff \fi \fl \ffi \ffl \hyphen.char \exclamdown 
 	\questiondown ];
-@GDEF_Mark = [\gravecomb \acutecomb \uni0302 \tildecomb \uni0304 \uni0306 \uni0307 
-	\uni0308 \uni030A \uni030B \uni030C \uni0327 \uni0328 \uni0326 ];
+@GDEF_Mark = [\uni0361 \gravecomb \acutecomb \uni0302 \tildecomb \uni0304 \uni0306 
+	\uni0307 \uni0308 \uni030A \uni030B \uni030C \uni0327 \uni0328 \uni0326 ];
 
 table GDEF {
   GlyphClassDef @GDEF_Simple, @GDEF_Ligature, @GDEF_Mark, ;

--- a/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
@@ -15,9 +15,9 @@
     <key>italicAngle</key>
     <real>-14.0</real>
     <key>note</key>
-    <string>2024-1-7: Created with FontForge (http://fontforge.org)</string>
+    <string>2024-1-15: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/01/08 04:33:10</string>
+    <string>2024/01/15 20:47:50</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>
@@ -27,7 +27,7 @@
     <key>openTypeNameLicense</key>
     <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://scripts.sil.org/OFL</string>
     <key>openTypeNameLicenseURL</key>
-    <string>https://scripts.sil.org/OFL</string>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameVersion</key>
     <string>Version 1.000</string>
     <key>openTypeOS2Selection</key>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/acutecomb.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/acutecomb.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="acutecomb" format="2">
-  <advance width="510"/>
+  <advance width="0"/>
   <unicode hex="0301"/>
   <anchor x="441.773" y="391.663" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/gravecomb.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/gravecomb.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="gravecomb" format="2">
-  <advance width="510"/>
+  <advance width="0"/>
   <unicode hex="0300"/>
   <anchor x="350.593" y="391.574" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/tildecomb.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/tildecomb.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="tildecomb" format="2">
-  <advance width="510"/>
+  <advance width="0"/>
   <unicode hex="0303"/>
   <anchor x="409.625" y="463.051" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0302.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0302.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0302" format="2">
-  <advance width="459"/>
+  <advance width="0"/>
   <unicode hex="0302"/>
   <anchor x="353.225" y="366.776" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0304.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0304.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0304" format="2">
-  <advance width="510"/>
+  <advance width="0"/>
   <unicode hex="0304"/>
   <anchor x="419.437" y="536.701" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0306.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0306.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0306" format="2">
-  <advance width="510"/>
+  <advance width="0"/>
   <unicode hex="0306"/>
   <anchor x="409.839" y="397.296" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0307.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0307.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0307" format="2">
-  <advance width="306"/>
+  <advance width="0"/>
   <unicode hex="0307"/>
   <anchor x="317.204" y="448.721" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0308.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0308.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0308" format="2">
-  <advance width="510"/>
+  <advance width="0"/>
   <unicode hex="0308"/>
   <anchor x="404.296" y="439.279" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni030A_.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni030A_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni030A" format="2">
-  <advance width="812"/>
+  <advance width="0"/>
   <unicode hex="030A"/>
   <anchor x="548.958" y="387.44" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni030B_.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni030B_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni030B" format="2">
-  <advance width="510"/>
+  <advance width="0"/>
   <unicode hex="030B"/>
   <anchor x="441.772" y="391.663" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni030C_.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni030C_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni030C" format="2">
-  <advance width="459"/>
+  <advance width="0"/>
   <unicode hex="030C"/>
   <anchor x="386.086" y="375.908" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0326.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0326.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0326" format="2">
-  <advance width="306"/>
+  <advance width="0"/>
   <unicode hex="0326"/>
   <anchor x="149.241" y="169.835" name="_BottomAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0327.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0327.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0327" format="2">
-  <advance width="459"/>
+  <advance width="0"/>
   <unicode hex="0327"/>
   <anchor x="191.922" y="-10" name="_BottomAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0328.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0328.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0328" format="2">
-  <advance width="306"/>
+  <advance width="0"/>
   <unicode hex="0328"/>
   <anchor x="109.712" y="0" name="_BottomAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0361.glif
+++ b/sources/ComputerModernClassic-Italic.ufo/glyphs/uni0361.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0361" format="2">
-  <advance width="357"/>
+  <advance width="0"/>
   <unicode hex="0361"/>
   <outline>
     <contour>

--- a/sources/ComputerModernClassic-Regular.ufo/features.fea
+++ b/sources/ComputerModernClassic-Regular.ufo/features.fea
@@ -2148,7 +2148,7 @@ feature size {
 	\egrave \eacute \ecircumflex \edieresis \igrave \iacute \icircumflex \idieresis 
 	\eth \ntilde \ograve \oacute \ocircumflex \otilde \odieresis \oe \oslash \ugrave 
 	\uacute \ucircumflex \udieresis \yacute \thorn \germandbls \arrowleft 
-	\arrowright \uni0361.alt \uni0361 \uni2040.alt \uni2040 \uni2422 \quotesingle 
+	\arrowright \uni0361.alt \uni2040.alt \uni2040 \uni2422 \quotesingle 
 	\asteriskmath \uniFE66 \fraction \zerooldstyle \oneoldstyle \twooldstyle 
 	\threeoldstyle \fouroldstyle \fiveoldstyle \sixoldstyle \sevenoldstyle 
 	\eightoldstyle \nineoldstyle \angleleft \minus \angleright \uni2127 \circle 
@@ -2170,8 +2170,8 @@ feature size {
 @GDEF_Ligature = [\quotedblleft \quotedblright \quotedblbase \guillemotleft 
 	\guillemotright \endash \emdash \ff \fi \fl \ffi \ffl \hyphen.char \exclamdown 
 	\questiondown ];
-@GDEF_Mark = [\gravecomb \acutecomb \uni0302 \tildecomb \uni0304 \uni0306 \uni0307 
-	\uni0308 \uni030A \uni030B \uni030C \uni0327 \uni0328 \uni0326 ];
+@GDEF_Mark = [\uni0361 \gravecomb \acutecomb \uni0302 \tildecomb \uni0304 \uni0306 
+	\uni0307 \uni0308 \uni030A \uni030B \uni030C \uni0327 \uni0328 \uni0326 ];
 
 table GDEF {
   GlyphClassDef @GDEF_Simple, @GDEF_Ligature, @GDEF_Mark, ;

--- a/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
@@ -15,9 +15,9 @@
     <key>italicAngle</key>
     <real>0.0</real>
     <key>note</key>
-    <string>2024-1-7: Created with FontForge (http://fontforge.org)</string>
+    <string>2024-1-15: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/01/08 04:32:42</string>
+    <string>2024/01/15 20:47:42</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>
@@ -27,7 +27,7 @@
     <key>openTypeNameLicense</key>
     <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://scripts.sil.org/OFL</string>
     <key>openTypeNameLicenseURL</key>
-    <string>https://scripts.sil.org/OFL</string>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameVersion</key>
     <string>Version 1.000</string>
     <key>openTypeOS2Selection</key>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/acutecomb.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/acutecomb.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="acutecomb" format="2">
-  <advance width="499"/>
+  <advance width="0"/>
   <unicode hex="0301"/>
   <anchor x="304.184" y="384.822" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/gravecomb.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/gravecomb.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="gravecomb" format="2">
-  <advance width="499"/>
+  <advance width="0"/>
   <unicode hex="0300"/>
   <anchor x="195.118" y="384.822" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/tildecomb.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/tildecomb.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="tildecomb" format="2">
-  <advance width="499"/>
+  <advance width="0"/>
   <unicode hex="0303"/>
   <anchor x="249.357" y="471.026" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0302.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0302.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0302" format="2">
-  <advance width="499"/>
+  <advance width="0"/>
   <unicode hex="0302"/>
   <anchor x="250" y="370.665" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0304.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0304.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0304" format="2">
-  <advance width="499"/>
+  <advance width="0"/>
   <unicode hex="0304"/>
   <anchor x="249.639" y="535.26" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0306.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0306.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0306" format="2">
-  <advance width="499"/>
+  <advance width="0"/>
   <unicode hex="0306"/>
   <anchor x="249.639" y="396.171" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0307.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0307.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0307" format="2">
-  <advance width="277"/>
+  <advance width="0"/>
   <unicode hex="0307"/>
   <anchor x="152.095" y="448.988" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0308.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0308.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0308" format="2">
-  <advance width="499"/>
+  <advance width="0"/>
   <unicode hex="0308"/>
   <anchor x="249.58" y="439.252" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni030A_.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni030A_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni030A" format="2">
-  <advance width="749"/>
+  <advance width="0"/>
   <unicode hex="030A"/>
   <anchor x="374.629" y="387.206" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni030B_.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni030B_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni030B" format="2">
-  <advance width="499"/>
+  <advance width="0"/>
   <unicode hex="030B"/>
   <anchor x="304.185" y="384.822" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni030C_.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni030C_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni030C" format="2">
-  <advance width="499"/>
+  <advance width="0"/>
   <unicode hex="030C"/>
   <anchor x="250" y="373.771" name="_TopAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0326.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0326.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0326" format="2">
-  <advance width="277"/>
+  <advance width="0"/>
   <unicode hex="0326"/>
   <anchor x="144.185" y="169.879" name="_BottomAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0327.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0327.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0327" format="2">
-  <advance width="444"/>
+  <advance width="0"/>
   <unicode hex="0327"/>
   <anchor x="221.805" y="-10" name="_BottomAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0328.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0328.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0328" format="2">
-  <advance width="277"/>
+  <advance width="0"/>
   <unicode hex="0328"/>
   <anchor x="114.943" y="0" name="_BottomAnchor"/>
   <outline>

--- a/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0361.glif
+++ b/sources/ComputerModernClassic-Regular.ufo/glyphs/uni0361.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0361" format="2">
-  <advance width="333"/>
+  <advance width="0"/>
   <unicode hex="0361"/>
   <outline>
     <contour>

--- a/sources/ff-gen.py
+++ b/sources/ff-gen.py
@@ -127,6 +127,9 @@ def create_combining(src_glyphname, dest_unicode):
     g = f.createChar(dest_unicode, dest_glyphname)
     f.selection.select(g)
     f.paste()
+    # FontBakery:com.google.fonts/check/gdef_spacing_marks wants zero
+    # width for marks.
+    g.width = 0
     return g
 
 def top_combining(g):
@@ -220,6 +223,11 @@ for (c, accent, uni, name) in ACCENTED_GLPYHS:
     g.appendAccent(unicode=accent)
     g.width = f[c].width
 
+# Fix for FontBakery:com.google.fonts/check/gdef_mark_chars.
+f['uni0361'].glyphclass = 'mark'
+# FontBakery:com.google.fonts/check/gdef_spacing_marks wants zero
+# width for marks.
+f['uni0361'].width = 0
 
 # The 'PfEd-lookups' is required to get the mark lookup to be exported.
 f.generate(ufo_file, flags=('PfEd-lookups',))


### PR DESCRIPTION
This PR fixes the following two FontBakery issues:

 - combining marks needs to have zero width
 - U+0361 (COMBINING DOUBLE INVERTED BREVE) is a combining mark.