### PR TITLE
Fix the FontBakery failure related to cedilla in Romanian

### DIFF
--- a/sources/ComputerModernClassic-Italic.ufo/features.fea
+++ b/sources/ComputerModernClassic-Italic.ufo/features.fea
@@ -1,9 +1,18 @@
 languagesystem DFLT dflt;
 languagesystem latn dflt;
+languagesystem latn ROM ;
 
 
 # GSUB 
 
+
+lookup loclRomanian {
+  lookupflag 0;
+    sub \Scedilla by \Scomma ;
+    sub \Tcedilla by \Tcomma ;
+    sub \scedilla by \scomma ;
+    sub \tcedilla by \tcomma ;
+} loclRomanian;
 
 lookup ligaStandardLigatureslookup0 {
   lookupflag 0;
@@ -23,6 +32,13 @@ lookup ligaStandardLigatureslookup0 {
     sub \exclam \quoteleft  by \exclamdown;
     sub \question \quoteleft  by \questiondown;
 } ligaStandardLigatureslookup0;
+
+feature locl {
+
+ script latn;
+     language ROM  exclude_dflt;
+      lookup loclRomanian;
+} locl;
 
 feature liga {
 

--- a/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
@@ -17,7 +17,7 @@
     <key>note</key>
     <string>2024-1-15: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/01/15 20:47:50</string>
+    <string>2024/01/15 22:38:40</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/ComputerModernClassic-Regular.ufo/features.fea
+++ b/sources/ComputerModernClassic-Regular.ufo/features.fea
@@ -1,9 +1,18 @@
 languagesystem DFLT dflt;
 languagesystem latn dflt;
+languagesystem latn ROM ;
 
 
 # GSUB 
 
+
+lookup loclRomanian {
+  lookupflag 0;
+    sub \Scedilla by \Scomma ;
+    sub \Tcedilla by \Tcomma ;
+    sub \scedilla by \scomma ;
+    sub \tcedilla by \tcomma ;
+} loclRomanian;
 
 lookup ligaStandardLigatureslookup0 {
   lookupflag 0;
@@ -23,6 +32,13 @@ lookup ligaStandardLigatureslookup0 {
     sub \exclam \quoteleft  by \exclamdown;
     sub \question \quoteleft  by \questiondown;
 } ligaStandardLigatureslookup0;
+
+feature locl {
+
+ script latn;
+     language ROM  exclude_dflt;
+      lookup loclRomanian;
+} locl;
 
 feature liga {
 

--- a/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
@@ -17,7 +17,7 @@
     <key>note</key>
     <string>2024-1-15: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/01/15 20:47:42</string>
+    <string>2024/01/15 22:38:32</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/ff-gen.py
+++ b/sources/ff-gen.py
@@ -229,5 +229,15 @@ f['uni0361'].glyphclass = 'mark'
 # width for marks.
 f['uni0361'].width = 0
 
+# Fix the FontBakery:com.google.fonts/check/glyphsets/shape_languages
+# related to Romanian.
+f.addLookup('loclRomanian', 'gsub_single', None, (('locl',(('latn',('ROM')),)),))
+f.addLookupSubtable('loclRomanian', 'loclRomanianSubtable')
+f['scedilla'].addPosSub('loclRomanianSubtable', 'scomma')
+f['Scedilla'].addPosSub('loclRomanianSubtable', 'Scomma')
+f['tcedilla'].addPosSub('loclRomanianSubtable', 'tcomma')
+f['Tcedilla'].addPosSub('loclRomanianSubtable', 'Tcomma')
+
+
 # The 'PfEd-lookups' is required to get the mark lookup to be exported.
 f.generate(ufo_file, flags=('PfEd-lookups',))


### PR DESCRIPTION
In Romanian the cedilla was used in the past as a poor substitute for comma for 's', 'S', 't', and 'T'.  This PR adds a lookup to replace those with the counterparts with commas.

This fixes the issue from #22.