### PR TITLE
Populate the OpenType meta table with Latn

### DIFF
--- a/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
@@ -17,7 +17,7 @@
     <key>note</key>
     <string>2024-1-15: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/01/15 22:38:40</string>
+    <string>2024/01/16 00:40:29</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/ComputerModernClassic-Italic.ufo/lib.plist
+++ b/sources/ComputerModernClassic-Italic.ufo/lib.plist
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.openTypeMeta</key>
+    <dict>
+      <key>dlng</key>
+      <array>
+        <string>Latn</string>
+      </array>
+      <key>slng</key>
+      <array>
+        <string>Latn</string>
+      </array>
+    </dict>
+  </dict>
+</plist>

--- a/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
@@ -17,7 +17,7 @@
     <key>note</key>
     <string>2024-1-15: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/01/15 22:38:32</string>
+    <string>2024/01/16 00:40:21</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/ComputerModernClassic-Regular.ufo/lib.plist
+++ b/sources/ComputerModernClassic-Regular.ufo/lib.plist
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.openTypeMeta</key>
+    <dict>
+      <key>dlng</key>
+      <array>
+        <string>Latn</string>
+      </array>
+      <key>slng</key>
+      <array>
+        <string>Latn</string>
+      </array>
+    </dict>
+  </dict>
+</plist>

--- a/sources/fix-fontinfo.py
+++ b/sources/fix-fontinfo.py
@@ -2,6 +2,7 @@
 
 import defcon
 import sys
+from fontTools.misc import plistlib
 
 f = defcon.Font(sys.argv[1])
 italic = 'Italic' in sys.argv[1]
@@ -53,3 +54,15 @@ f.info.openTypeOS2TypoAscender = f.info.openTypeHheaAscender
 f.info.openTypeOS2TypoDescender = f.info.openTypeHheaDescender
 
 f.save(sys.argv[1])
+
+# Manually create a lib.plist to populate the OpenType meta table
+# because the defcon library doesn't have yet support for it.
+#
+# This fixes the FontBakery:com.google.fonts/check/meta/script_lang_tags check.
+with open(sys.argv[1] + '/lib.plist', 'wb') as lib_file:
+    plistlib.dump({
+        'public.openTypeMeta': {
+            'dlng': ['Latn'],
+            'slng': ['Latn'],
+        }
+    }, lib_file, pretty_print=True)


### PR DESCRIPTION
The FontBakery com.google.fonts/check/meta/script_lang_tags check requires the meta table to be populated. It's not clear to me if Latn is sufficient or not.