### PR TITLE
Replace 'latn' with 'DFLT' for the Romanian lookup table

### DIFF
--- a/sources/ComputerModernClassic-Italic.ufo/features.fea
+++ b/sources/ComputerModernClassic-Italic.ufo/features.fea
@@ -1,6 +1,6 @@
 languagesystem DFLT dflt;
+languagesystem DFLT ROM ;
 languagesystem latn dflt;
-languagesystem latn ROM ;
 
 
 # GSUB 
@@ -35,7 +35,7 @@ lookup ligaStandardLigatureslookup0 {
 
 feature locl {
 
- script latn;
+ script DFLT;
      language ROM  exclude_dflt;
       lookup loclRomanian;
 } locl;

--- a/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Italic.ufo/fontinfo.plist
@@ -17,7 +17,7 @@
     <key>note</key>
     <string>2024-1-15: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/01/16 00:40:29</string>
+    <string>2024/01/16 01:10:55</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/ComputerModernClassic-Regular.ufo/features.fea
+++ b/sources/ComputerModernClassic-Regular.ufo/features.fea
@@ -1,6 +1,6 @@
 languagesystem DFLT dflt;
+languagesystem DFLT ROM ;
 languagesystem latn dflt;
-languagesystem latn ROM ;
 
 
 # GSUB 
@@ -35,7 +35,7 @@ lookup ligaStandardLigatureslookup0 {
 
 feature locl {
 
- script latn;
+ script DFLT;
      language ROM  exclude_dflt;
       lookup loclRomanian;
 } locl;

--- a/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
+++ b/sources/ComputerModernClassic-Regular.ufo/fontinfo.plist
@@ -17,7 +17,7 @@
     <key>note</key>
     <string>2024-1-15: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/01/16 00:40:21</string>
+    <string>2024/01/16 01:10:47</string>
     <key>openTypeHheaAscender</key>
     <integer>900</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/ff-gen.py
+++ b/sources/ff-gen.py
@@ -231,7 +231,7 @@ f['uni0361'].width = 0
 
 # Fix the FontBakery:com.google.fonts/check/glyphsets/shape_languages
 # related to Romanian.
-f.addLookup('loclRomanian', 'gsub_single', None, (('locl',(('latn',('ROM')),)),))
+f.addLookup('loclRomanian', 'gsub_single', None, (('locl',(('DFLT',('ROM')),)),))
 f.addLookupSubtable('loclRomanian', 'loclRomanianSubtable')
 f['scedilla'].addPosSub('loclRomanianSubtable', 'scomma')
 f['Scedilla'].addPosSub('loclRomanianSubtable', 'Scomma')


### PR DESCRIPTION
The lookup table added in PR #27 turned off of the existing ligatures. Using the 'DFLT' instead of 'latn' seems to fix the issue.